### PR TITLE
🔄 Bump version to 1.1.0-SNAPSHOT

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "org.cli-todoer"
-version = "1.0-SNAPSHOT"
+version = "1.1.0-SNAPSHOT"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Backport next snapshot version after 1.0.1