### PR TITLE
🔄 Bump version to 1.2.1-SNAPSHOT

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "org.cli-todoer"
-version = "1.0-SNAPSHOT"
+version = "1.2.1-SNAPSHOT"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Backport next snapshot version after 1.1.1